### PR TITLE
Drop hard coded `DifficultyLevel` in beatmap file

### DIFF
--- a/Renako.Game/Beatmaps/Beatmap.cs
+++ b/Renako.Game/Beatmaps/Beatmap.cs
@@ -31,11 +31,6 @@ public class Beatmap
     public string DifficultyName { get; set; }
 
     /// <summary>
-    /// The difficulty level of the beatmap that's roughly based from rating.
-    /// </summary>
-    public DifficultyLevel DifficultyLevel { get; set; }
-
-    /// <summary>
     /// The calculated difficulty rating of the beatmap.
     /// </summary>
     public double DifficultyRating { get; set; }
@@ -62,19 +57,18 @@ public class Beatmap
                EqualityComparer<BeatmapSet>.Default.Equals(BeatmapSet, beatmap.BeatmapSet) &&
                Creator == beatmap.Creator &&
                DifficultyName == beatmap.DifficultyName &&
-               DifficultyLevel == beatmap.DifficultyLevel &&
                DifficultyRating == beatmap.DifficultyRating &&
                BackgroundPath == beatmap.BackgroundPath;
     }
 
     protected bool Equals(Beatmap other)
     {
-        return ID == other.ID && Equals(BeatmapSet, other.BeatmapSet) && Creator == other.Creator && DifficultyName == other.DifficultyName && DifficultyLevel == other.DifficultyLevel && DifficultyRating.Equals(other.DifficultyRating) && BackgroundPath == other.BackgroundPath;
+        return ID == other.ID && Equals(BeatmapSet, other.BeatmapSet) && Creator == other.Creator && DifficultyName == other.DifficultyName && DifficultyRating.Equals(other.DifficultyRating) && BackgroundPath == other.BackgroundPath;
     }
 
     public override int GetHashCode()
     {
-        return HashCode.Combine(ID, BeatmapSet, Creator, DifficultyName, (int)DifficultyLevel, DifficultyRating, BackgroundPath);
+        return HashCode.Combine(ID, BeatmapSet, Creator, DifficultyName, DifficultyRating, BackgroundPath);
     }
 
     /// <summary>

--- a/Renako.Game/Utilities/BeatmapTestUtility.cs
+++ b/Renako.Game/Utilities/BeatmapTestUtility.cs
@@ -211,7 +211,6 @@ public class BeatmapTestUtility
                     ID = incrementID,
                     BeatmapSet = beatmapSet,
                     Creator = GetRandomCreatorName(),
-                    DifficultyLevel = BeatmapUtility.CalculateDifficultyLevel(difficultyRating),
                     DifficultyName = BeatmapUtility.CalculateDifficultyLevel(difficultyRating) + " " + difficultyLevel,
                     DifficultyRating = difficultyRating,
                     BackgroundPath = beatmapSet.BackgroundPath,


### PR DESCRIPTION
During refactor something just notice that somehow we still hard code this enum and not use anywhere since we already change the color [a really long time ago](https://github.com/HelloYeew/renako/pull/8) so just remove this. The old beatmap will not effected by this change since we now mostly depend on difficulty level that's `double` to do thing on beatmap.